### PR TITLE
Explicitly use C11 dialect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ INCLUDE  = -I$(INCDIR) -Icmsis
 LSCRIPT = STM32F103X8_FLASH.ld
 
 # C Flags
-GCFLAGS  = -std=c11 -Wall -fno-common -mthumb -mcpu=$(CPU) -DSTM32F103xB --specs=nosys.specs -g -Wa,-ahlms=$(addprefix $(OBJDIR)/,$(notdir $(<:.c=.lst)))
+GCFLAGS  = -std=c99 -Wall -fno-common -mthumb -mcpu=$(CPU) -DSTM32F103xB --specs=nosys.specs -g -Wa,-ahlms=$(addprefix $(OBJDIR)/,$(notdir $(<:.c=.lst)))
 GCFLAGS += $(INCLUDE)
 LDFLAGS += -T$(LSCRIPT) -mthumb -mcpu=$(CPU) --specs=nosys.specs 
 ASFLAGS += -mcpu=$(CPU)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ INCLUDE  = -I$(INCDIR) -Icmsis
 LSCRIPT = STM32F103X8_FLASH.ld
 
 # C Flags
-GCFLAGS  = -Wall -fno-common -mthumb -mcpu=$(CPU) -DSTM32F103xB --specs=nosys.specs -g -Wa,-ahlms=$(addprefix $(OBJDIR)/,$(notdir $(<:.c=.lst)))
+GCFLAGS  = -std=c11 -Wall -fno-common -mthumb -mcpu=$(CPU) -DSTM32F103xB --specs=nosys.specs -g -Wa,-ahlms=$(addprefix $(OBJDIR)/,$(notdir $(<:.c=.lst)))
 GCFLAGS += $(INCLUDE)
 LDFLAGS += -T$(LSCRIPT) -mthumb -mcpu=$(CPU) --specs=nosys.specs 
 ASFLAGS += -mcpu=$(CPU)


### PR DESCRIPTION
Hi,

Thanks for creating this project. On Ubuntu Xenial with the `arm-none-eabi-gcc` package, the supplied makefile gives these errors:

```
src/main.c: In function 'main':
src/main.c:21:9: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
         for (uint16_t i = 0; i != 0xffff; i++) { }
         ^
src/main.c:21:9: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
src/main.c:24:23: error: redefinition of 'i'
         for (uint16_t i = 0; i != 0xffff; i++) { }
                       ^
```

Adding `-std=c11` as the error suggests returns everything to working order. Just thought this might save some future person a bad 'out of box' experience.
